### PR TITLE
[Feat] NetworkManager 구현 및 iTunes API 호출하기

### DIFF
--- a/LZTunes/LZTunes.xcodeproj/project.pbxproj
+++ b/LZTunes/LZTunes.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		CE32EFDE2C65222300540192 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFDD2C65222300540192 /* BaseViewController.swift */; };
 		CE32EFE12C670F2D00540192 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFE02C670F2D00540192 /* NetworkManager.swift */; };
 		CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFE32C671B0900540192 /* iTunesRouter.swift */; };
+		CE32EFE72C67331800540192 /* iTunesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFE62C67331800540192 /* iTunesResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		CE32EFDD2C65222300540192 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		CE32EFE02C670F2D00540192 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		CE32EFE32C671B0900540192 /* iTunesRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTunesRouter.swift; sourceTree = "<group>"; };
+		CE32EFE62C67331800540192 /* iTunesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTunesResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,8 +117,9 @@
 		CE32EFD42C6520F000540192 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				CE32EFE22C671B0200540192 /* Routers */,
 				CE32EFDF2C670F2400540192 /* Managers */,
+				CE32EFE52C67330B00540192 /* Models */,
+				CE32EFE22C671B0200540192 /* Routers */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -152,6 +155,14 @@
 				CE32EFE32C671B0900540192 /* iTunesRouter.swift */,
 			);
 			path = Routers;
+			sourceTree = "<group>";
+		};
+		CE32EFE52C67330B00540192 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				CE32EFE62C67331800540192 /* iTunesResponse.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -229,6 +240,7 @@
 				CE32EFBD2C651EF600540192 /* ViewController.swift in Sources */,
 				CE32EFB92C651EF600540192 /* AppDelegate.swift in Sources */,
 				CE32EFE12C670F2D00540192 /* NetworkManager.swift in Sources */,
+				CE32EFE72C67331800540192 /* iTunesResponse.swift in Sources */,
 				CE32EFBB2C651EF600540192 /* SceneDelegate.swift in Sources */,
 				CE32EFD82C65214800540192 /* BaseView.swift in Sources */,
 				CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */,

--- a/LZTunes/LZTunes.xcodeproj/project.pbxproj
+++ b/LZTunes/LZTunes.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		CE32EFD82C65214800540192 /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFD72C65214800540192 /* BaseView.swift */; };
 		CE32EFDC2C65221400540192 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFDB2C65221400540192 /* ViewModel.swift */; };
 		CE32EFDE2C65222300540192 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFDD2C65222300540192 /* BaseViewController.swift */; };
+		CE32EFE12C670F2D00540192 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFE02C670F2D00540192 /* NetworkManager.swift */; };
+		CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFE32C671B0900540192 /* iTunesRouter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,8 @@
 		CE32EFD72C65214800540192 /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
 		CE32EFDB2C65221400540192 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		CE32EFDD2C65222300540192 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
+		CE32EFE02C670F2D00540192 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
+		CE32EFE32C671B0900540192 /* iTunesRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTunesRouter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +115,8 @@
 		CE32EFD42C6520F000540192 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				CE32EFE22C671B0200540192 /* Routers */,
+				CE32EFDF2C670F2400540192 /* Managers */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -130,6 +136,22 @@
 				CE32EFDB2C65221400540192 /* ViewModel.swift */,
 			);
 			path = Bases;
+			sourceTree = "<group>";
+		};
+		CE32EFDF2C670F2400540192 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				CE32EFE02C670F2D00540192 /* NetworkManager.swift */,
+			);
+			path = Managers;
+			sourceTree = "<group>";
+		};
+		CE32EFE22C671B0200540192 /* Routers */ = {
+			isa = PBXGroup;
+			children = (
+				CE32EFE32C671B0900540192 /* iTunesRouter.swift */,
+			);
+			path = Routers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -206,8 +228,10 @@
 				CE32EFDC2C65221400540192 /* ViewModel.swift in Sources */,
 				CE32EFBD2C651EF600540192 /* ViewController.swift in Sources */,
 				CE32EFB92C651EF600540192 /* AppDelegate.swift in Sources */,
+				CE32EFE12C670F2D00540192 /* NetworkManager.swift in Sources */,
 				CE32EFBB2C651EF600540192 /* SceneDelegate.swift in Sources */,
 				CE32EFD82C65214800540192 /* BaseView.swift in Sources */,
+				CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */,
 				CE32EFDE2C65222300540192 /* BaseViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LZTunes/LZTunes/Sources/Presenters/Bases/ViewModel.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Bases/ViewModel.swift
@@ -124,10 +124,13 @@ class TestViewModel: ViewModel {
     
     
     func testFunction() {
-        let a: String = store.testInput
-        let b: KeyPath<Input, String> = store.testInput
-        let c: WritableKeyPath<Input, String> = store.testInput
+        let stringTypeInput: String = store.testInput
+        let keyPathTypeInput: KeyPath<Input, String> = store.testInput
+        let writableKeyPathTypeInput: WritableKeyPath<Input, String> = store.testInput
         
+        print(type(of: stringTypeInput))
+        print(type(of: keyPathTypeInput))
+        print(type(of: writableKeyPathTypeInput))
         store.reduce(store.testInput, into: "changed")
     }
 }

--- a/LZTunes/LZTunes/Sources/Presenters/ViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/ViewController.swift
@@ -39,9 +39,8 @@ final class ViewController: BaseViewController<ViewControllerView, ViewControlle
         navigationItem.title = viewModel.store.navigationTitle
         view.backgroundColor = viewModel.store.backgroundColor
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
-            self?.viewModel.testFunction()
-        }
+//        iTunesRouter.search(searchText: "bts").build()
+        NetworkManager.shared.requestCall()
     }
 }
 

--- a/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
@@ -6,3 +6,73 @@
 //
 
 import Foundation
+
+final class NetworkManager: NSObject {
+    static let shared = NetworkManager()
+    
+    override private init() { }
+    
+    var buffer: Data?
+    
+    func requestCall() {
+        let urlRequest = iTunesRouter
+            .search(searchText: "apple")
+            .build()
+        if let urlRequest = urlRequest {
+            let session = URLSession(
+                configuration: .default,
+                delegate: self,
+                delegateQueue: .current
+            )
+            
+            let dataTask = session.dataTask(with: urlRequest)
+            dataTask.resume()
+        }
+    }
+}
+
+extension NetworkManager: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse) async -> URLSession.ResponseDisposition {
+        if let response = response as? HTTPURLResponse, (200...299).contains(response.statusCode) {
+                print("allowed")
+                buffer = Data()
+                return .allow
+            } else {
+                print("not allowed")
+                buffer = nil
+                return .cancel
+            }
+    }
+    
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        
+        print("downloading...")
+        buffer?.append(data)
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
+        guard error == nil else {
+            print("URLSession Data Task Error: \(error)")
+            return
+        }
+        
+        
+        if let buffer = buffer {
+            let decodedData = try! JSONDecoder().decode(iTunesResponse.self, from: buffer)
+            print("decoded data: \(decodedData)")
+        } else {
+            print("nil buffer")
+        }
+    }
+    
+}
+
+struct iTunesResponse: Decodable {
+    let resultCount: Int
+    let results: [iTunesResult]
+}
+
+struct iTunesResult: Decodable {
+    let kind: String?
+    let artistViewUrl: String?
+}

--- a/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
@@ -12,7 +12,7 @@ final class NetworkManager: NSObject {
     
     override private init() { }
     
-    var buffer: Data?
+    private var buffer: Data?
     
     func requestCall() {
         let urlRequest = iTunesRouter
@@ -52,7 +52,7 @@ extension NetworkManager: URLSessionDataDelegate {
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
         guard error == nil else {
-            print("URLSession Data Task Error: \(error)")
+            print("URLSession Data Task Error: \(String(describing: error))")
             return
         }
         

--- a/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
@@ -1,0 +1,8 @@
+//
+//  NetworkManager.swift
+//  LZTunes
+//
+//  Created by user on 8/10/24.
+//
+
+import Foundation

--- a/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Managers/NetworkManager.swift
@@ -67,12 +67,3 @@ extension NetworkManager: URLSessionDataDelegate {
     
 }
 
-struct iTunesResponse: Decodable {
-    let resultCount: Int
-    let results: [iTunesResult]
-}
-
-struct iTunesResult: Decodable {
-    let kind: String?
-    let artistViewUrl: String?
-}

--- a/LZTunes/LZTunes/Sources/Utils/Models/iTunesResponse.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Models/iTunesResponse.swift
@@ -1,0 +1,16 @@
+//
+//  iTunesResponse.swift
+//  LZTunes
+//
+//  Created by user on 8/10/24.
+//
+
+struct iTunesResponse: Decodable {
+    let resultCount: Int
+    let results: [iTunesResult]
+}
+
+struct iTunesResult: Decodable {
+    let kind: String?
+    let artistViewUrl: String?
+}

--- a/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
@@ -1,0 +1,67 @@
+//
+//  iTunesRouter.swift
+//  LZTunes
+//
+//  Created by user on 8/10/24.
+//
+
+import Foundation
+enum iTunesRouter: Router {
+    case search(searchText: String)
+    
+    var baseURL: String {
+        switch self {
+        case .search:
+            return "https://itunes.apple.com"
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .search:
+            return "/search"
+        }
+    }
+    
+    var httpMethod: String {
+        switch self {
+        case .search:
+            return "GET"
+        }
+    }
+    
+    var queryItems: [URLQueryItem] {
+        switch self {
+        case .search(searchText: let searchText):
+            let queryItems = [
+                URLQueryItem(name: "term", value: searchText)
+            ]
+            
+            return queryItems
+        }
+    }
+    
+    
+    func build() -> URLRequest? {
+        let requestType = Self.search(searchText: "apple")
+        
+        let url = requestType.baseURL
+        
+        var components = URLComponents(string: url)
+        components?.path = requestType.path
+        components?.queryItems = requestType.queryItems
+        
+        
+        if let composedURL = components?.url {
+            let request = URLRequest(url: composedURL)
+            return request
+        }
+        
+        return nil
+    }
+}
+
+
+protocol Router {
+    func build() -> URLRequest?
+}


### PR DESCRIPTION
# 📱 *Pull requests* 🎶

🌿 **작업한 브랜치**
Link: https://github.com/alpaka99/LZTunes/tree/%236/Feat/Implement-iTunes-API-Call

<br></br>

## 🔍 **작업한 결과**
### iTunes API 호출하기
> iTunes API 공식 문서
https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI/Searching.html#//apple_ref/doc/uid/TP40017632-CH5-SW1
- iTunes API 공식 문서를 참고하여 API 호출을 했습니다.

### iTunesRouter
> URLComponents & Router Pattern
- URLSession을 이용한 네트워크 통신을 위하여 URLComponents를 사용하였습니다.
- URLComponents에 필요한 데이터들을 구현하기 위하여 RouterPattern을 따르는 객체를 추상화 하기 위하여 Router Protocol을 구현하였음며, Router Protocol을 채택하는 객체인 iTunesRouter를 정의하였습니다.
- iTunesRouter는 baseURL, path, parameter들을 갖고, 이를 마지막에 build() 메서드를 통해 request에 적합한 URLRequest 형태로 변형시킵니다
```swift
protocol Router {
    func build() -> URLRequest
}
```

### NetworkManager
> Singleton & URLSessionDataDelegate
- 외부와의 네트워크 통신은 하나의 객체에서 관리하기 위하여 싱글톤 객체인 NetworkManager를 정의하였습니다.
- 네트워크 통신에 대한 응답을 처리하기 위해, NetworkManager 객체는 URLSessionDataDelegate 프로토콜을 채택하며, 
    1. 초기 상태코드 확인을 위한 urlSession(didReceive response: )
    2. 다운로드 중일때의 처리를 위한 urlSesison(didReceive data: )
    3. 다운로드가 중단 혹은 완료 되었을때의 처리를 위한 urlSesison(didCompleteWithError error: )
- 메서드를 구현하였습니다

<br></br>
## 🔫 **Trouble Shooting**
### URLSession & URLSessionDataDelegate
- 기존에 사용하던 Alamofier와는 다른 URLSesison을 사용하여 손에 익숙하지 않아서 시간이 예상보다 조금 더 걸렸습니다.
- 또한 URLSessionDataDelegate를 채택해야하는데 URLSessionTaskDelegate를 채택하여 메서드들을 불러오지 못하는 문제들이 있었고
- buffer의 초기 optional 구현, 추후 사용시에 optional 해제 등의 문제들에 대한 고민을 할 수 있는 시간이었습니다.

<br></br>
## 🔊 기타 공유사항
### NetworkManager의 상세 구현
- 현재는 임시 값들을 통해서 NetworkManager들이 동작하고 있으며, dataTask에서의 response, error, data도 print로만 처리되고 있습니다.
- 이 부분들은 추후에 RxSwift 라이브러리를 import 하고 ObservableStream에 대한 처리를 해주면서 수정해줘야하는 부분입니다!

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
||<img src = "">|
||<img src = "">|
<br></br>

## 📟 관련 이슈
- Resolved: #6 
