### PR TITLE
[Feat] SearchTableViewCell 구현, DetailSearchView 구현

### DIFF
--- a/LZTunes/LZTunes.xcodeproj/project.pbxproj
+++ b/LZTunes/LZTunes.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		CE32EFF92C68FEF100540192 /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */; };
 		CE32EFFB2C68FF0700540192 /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFFA2C68FF0700540192 /* BaseTableViewCell.swift */; };
 		CE32EFFE2C69060900540192 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = CE32EFFD2C69060900540192 /* Kingfisher */; };
+		CE32F0012C690FB300540192 /* DetailSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32F0002C690FB300540192 /* DetailSearchView.swift */; };
+		CE32F0032C69113F00540192 /* DetailSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32F0022C69113F00540192 /* DetailSearchViewModel.swift */; };
+		CE32F0052C6912E100540192 /* DetailSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32F0042C6912E100540192 /* DetailSearchViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -50,6 +53,9 @@
 		CE32EFF32C6747AD00540192 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
 		CE32EFFA2C68FF0700540192 /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
+		CE32F0002C690FB300540192 /* DetailSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchView.swift; sourceTree = "<group>"; };
+		CE32F0022C69113F00540192 /* DetailSearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchViewModel.swift; sourceTree = "<group>"; };
+		CE32F0042C6912E100540192 /* DetailSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailSearchViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -126,6 +132,7 @@
 		CE32EFD12C6520E000540192 /* Presenters */ = {
 			isa = PBXGroup;
 			children = (
+				CE32EFFF2C690FAB00540192 /* DetailSearch */,
 				CE32EFF02C67479C00540192 /* Search */,
 				CE32EFD62C65213900540192 /* Bases */,
 			);
@@ -194,6 +201,16 @@
 				CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		CE32EFFF2C690FAB00540192 /* DetailSearch */ = {
+			isa = PBXGroup;
+			children = (
+				CE32F0002C690FB300540192 /* DetailSearchView.swift */,
+				CE32F0022C69113F00540192 /* DetailSearchViewModel.swift */,
+				CE32F0042C6912E100540192 /* DetailSearchViewController.swift */,
+			);
+			path = DetailSearch;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -280,6 +297,7 @@
 			files = (
 				CE32EFF22C6747A500540192 /* SearchViewModel.swift in Sources */,
 				CE32EFDC2C65221400540192 /* ViewModel.swift in Sources */,
+				CE32F0052C6912E100540192 /* DetailSearchViewController.swift in Sources */,
 				CE32EFEA2C673FDF00540192 /* iTunesRespository.swift in Sources */,
 				CE32EFBD2C651EF600540192 /* SearchViewController.swift in Sources */,
 				CE32EFFB2C68FF0700540192 /* BaseTableViewCell.swift in Sources */,
@@ -289,8 +307,10 @@
 				CE32EFE72C67331800540192 /* iTunesResponse.swift in Sources */,
 				CE32EFF92C68FEF100540192 /* SearchTableViewCell.swift in Sources */,
 				CE32EFBB2C651EF600540192 /* SceneDelegate.swift in Sources */,
+				CE32F0032C69113F00540192 /* DetailSearchViewModel.swift in Sources */,
 				CE32EFD82C65214800540192 /* BaseView.swift in Sources */,
 				CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */,
+				CE32F0012C690FB300540192 /* DetailSearchView.swift in Sources */,
 				CE32EFDE2C65222300540192 /* BaseViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LZTunes/LZTunes.xcodeproj/project.pbxproj
+++ b/LZTunes/LZTunes.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		CE32EFF22C6747A500540192 /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFF12C6747A500540192 /* SearchViewModel.swift */; };
 		CE32EFF42C6747AD00540192 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFF32C6747AD00540192 /* SearchView.swift */; };
 		CE32EFF72C67615200540192 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = CE32EFF62C67615200540192 /* SnapKit */; };
+		CE32EFF92C68FEF100540192 /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */; };
+		CE32EFFB2C68FF0700540192 /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE32EFFA2C68FF0700540192 /* BaseTableViewCell.swift */; };
+		CE32EFFE2C69060900540192 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = CE32EFFD2C69060900540192 /* Kingfisher */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +48,8 @@
 		CE32EFE92C673FDF00540192 /* iTunesRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iTunesRespository.swift; sourceTree = "<group>"; };
 		CE32EFF12C6747A500540192 /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		CE32EFF32C6747AD00540192 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
+		CE32EFFA2C68FF0700540192 /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE32EFFE2C69060900540192 /* Kingfisher in Frameworks */,
 				CE32EFF72C67615200540192 /* SnapKit in Frameworks */,
 				CE32EFEF2C67401B00540192 /* RxSwift in Frameworks */,
 				CE32EFED2C67401B00540192 /* RxCocoa in Frameworks */,
@@ -150,6 +156,7 @@
 				CE32EFD72C65214800540192 /* BaseView.swift */,
 				CE32EFDD2C65222300540192 /* BaseViewController.swift */,
 				CE32EFDB2C65221400540192 /* ViewModel.swift */,
+				CE32EFFA2C68FF0700540192 /* BaseTableViewCell.swift */,
 			);
 			path = Bases;
 			sourceTree = "<group>";
@@ -184,6 +191,7 @@
 				CE32EFF32C6747AD00540192 /* SearchView.swift */,
 				CE32EFF12C6747A500540192 /* SearchViewModel.swift */,
 				CE32EFBC2C651EF600540192 /* SearchViewController.swift */,
+				CE32EFF82C68FEF100540192 /* SearchTableViewCell.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -208,6 +216,7 @@
 				CE32EFEC2C67401B00540192 /* RxCocoa */,
 				CE32EFEE2C67401B00540192 /* RxSwift */,
 				CE32EFF62C67615200540192 /* SnapKit */,
+				CE32EFFD2C69060900540192 /* Kingfisher */,
 			);
 			productName = LZTunes;
 			productReference = CE32EFB52C651EF600540192 /* LZTunes.app */;
@@ -240,6 +249,7 @@
 			packageReferences = (
 				CE32EFEB2C67401B00540192 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				CE32EFF52C67615200540192 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				CE32EFFC2C69060900540192 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = CE32EFB62C651EF600540192 /* Products */;
 			projectDirPath = "";
@@ -272,10 +282,12 @@
 				CE32EFDC2C65221400540192 /* ViewModel.swift in Sources */,
 				CE32EFEA2C673FDF00540192 /* iTunesRespository.swift in Sources */,
 				CE32EFBD2C651EF600540192 /* SearchViewController.swift in Sources */,
+				CE32EFFB2C68FF0700540192 /* BaseTableViewCell.swift in Sources */,
 				CE32EFF42C6747AD00540192 /* SearchView.swift in Sources */,
 				CE32EFB92C651EF600540192 /* AppDelegate.swift in Sources */,
 				CE32EFE12C670F2D00540192 /* NetworkManager.swift in Sources */,
 				CE32EFE72C67331800540192 /* iTunesResponse.swift in Sources */,
+				CE32EFF92C68FEF100540192 /* SearchTableViewCell.swift in Sources */,
 				CE32EFBB2C651EF600540192 /* SceneDelegate.swift in Sources */,
 				CE32EFD82C65214800540192 /* BaseView.swift in Sources */,
 				CE32EFE42C671B0900540192 /* iTunesRouter.swift in Sources */,
@@ -518,6 +530,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		CE32EFFC2C69060900540192 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.12.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -535,6 +555,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CE32EFF52C67615200540192 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		CE32EFFD2C69060900540192 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CE32EFFC2C69060900540192 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/LZTunes/LZTunes/Sources/Domains/iTunesRespository.swift
+++ b/LZTunes/LZTunes/Sources/Domains/iTunesRespository.swift
@@ -35,8 +35,10 @@ final class iTunesRepository {
             .bind(with: self) { owner, completeStatus in
                 switch completeStatus {
                 case .complete(let data):
-                    let decodedData = try! JSONDecoder().decode(iTunesResponse.self, from: data)
-                    owner.searchResult.onNext(decodedData.results)
+                    let decodedData = try? JSONDecoder().decode(iTunesResponse.self, from: data)
+                    if let decodedData = decodedData {
+                        owner.searchResult.onNext(decodedData.results)
+                    }
                 case .error(let error):
                     print("Error", error)
                 }

--- a/LZTunes/LZTunes/Sources/Presenters/Bases/BaseTableViewCell.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Bases/BaseTableViewCell.swift
@@ -1,0 +1,35 @@
+//
+//  BaseTableViewCell.swift
+//  LZTunes
+//
+//  Created by user on 8/11/24.
+//
+
+import UIKit
+
+class BaseTableViewCell: UITableViewCell, Reusable {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        configureHierarchy()
+        configureLayout()
+        configureUI()
+    }
+    
+    @available(iOS, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureHierarchy() { }
+    func configureLayout() { }
+    func configureUI() { }
+}
+
+protocol Reusable { }
+
+extension Reusable {
+    static var identifier: String {
+        return String(describing: self)
+    }
+}

--- a/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchView.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchView.swift
@@ -1,0 +1,32 @@
+//
+//  DetailSearchView.swift
+//  LZTunes
+//
+//  Created by user on 8/12/24.
+//
+
+import UIKit
+import WebKit
+
+import SnapKit
+
+final class DetailSearchView: BaseView {
+    let webView = {
+        let view = WKWebView()
+        return view
+    }()
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        self.addSubview(webView)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        webView.snp.makeConstraints { view in
+            view.edges.equalTo(self.safeAreaLayoutGuide)
+        }
+    }
+}

--- a/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchViewController.swift
@@ -1,0 +1,29 @@
+//
+//  DetailSearchViewController.swift
+//  LZTunes
+//
+//  Created by user on 8/12/24.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+
+final class DetailSearchViewController: BaseViewController<DetailSearchView, DetailSearchViewModel> {
+    
+    let disposeBag = DisposeBag()
+    
+    override func configureBind() {
+        super.configureBind()
+        
+        viewModel.store.detailViewURL
+            .bind(with: self) { owner, urlString in
+                if let url = URL(string: urlString) {
+                    let request = URLRequest(url: url)
+                    owner.baseView.webView.load(request)
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchViewModel.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/DetailSearch/DetailSearchViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  DetailSearchViewModel.swift
+//  LZTunes
+//
+//  Created by user on 8/12/24.
+//
+
+import Foundation
+
+import RxSwift
+
+final class DetailSearchViewModel: ViewModel {
+    struct Input: Inputable {
+        var detailViewURL = BehaviorSubject(value: "")
+    }
+    
+    struct Output: Outputable {
+        
+    }
+    
+    var store = ViewStore(input: Input(), output: Output())
+}

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchTableViewCell.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchTableViewCell.swift
@@ -36,13 +36,12 @@ final class SearchTableViewCell: BaseTableViewCell {
         super.configureLayout()
         
         thumbnailImage.snp.makeConstraints { img in
-//            img.verticalEdges.equalTo(self)
-//                .inset(8)
+
             img.leading.equalTo(self.snp.leading)
                 .offset(8)
-            img.size.equalTo(44)
-            img.verticalEdges.equalTo(self)
-                .inset(8)
+            img.size.equalTo(50)
+//            img.verticalEdges.equalTo(self)
+//                .inset(8)
         }
         
         musicNameLabel.snp.makeConstraints { label in

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchTableViewCell.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchTableViewCell.swift
@@ -1,0 +1,55 @@
+//
+//  SearchTableViewCell.swift
+//  LZTunes
+//
+//  Created by user on 8/11/24.
+//
+
+import UIKit
+
+import SnapKit
+
+final class SearchTableViewCell: BaseTableViewCell {
+    let thumbnailImage = {
+        let imageView = UIImageView()
+        imageView.layer.masksToBounds = true
+        imageView.layer.cornerRadius = 4
+        return imageView
+    }()
+    
+    let musicNameLabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        label.textColor = .black
+        return label
+    }()
+    
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        contentView.addSubview(thumbnailImage)
+        contentView.addSubview(musicNameLabel)
+    }
+    
+    override func configureLayout() {
+        super.configureLayout()
+        
+        thumbnailImage.snp.makeConstraints { img in
+//            img.verticalEdges.equalTo(self)
+//                .inset(8)
+            img.leading.equalTo(self.snp.leading)
+                .offset(8)
+            img.size.equalTo(44)
+            img.verticalEdges.equalTo(self)
+                .inset(8)
+        }
+        
+        musicNameLabel.snp.makeConstraints { label in
+            label.leading.equalTo(thumbnailImage.snp.trailing)
+                .offset(8)
+            label.trailing.equalTo(self)
+            label.centerY.equalTo(thumbnailImage.snp.centerY)
+        }
+    }
+}

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
@@ -70,8 +70,12 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
         viewModel.store.detailViewURL
             .bind(with: self) { owner, data in
                 if let collectionViewUrl = data {
-                    print(collectionViewUrl)
-
+                    let detailSearchViewModel = DetailSearchViewModel()
+                    detailSearchViewModel.store.detailViewURL.onNext(collectionViewUrl)
+                    
+                    let detailSearchViewController = DetailSearchViewController(baseView: DetailSearchView(), viewModel: detailSearchViewModel)
+                    
+                    owner.navigationController?.pushViewController(detailSearchViewController, animated: true)
                 }
             }
             .disposed(by: disposeBag)

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+import Kingfisher
 import RxCocoa
 import RxSwift
 
@@ -26,7 +27,8 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
     override func configureDelegate() {
         super.configureDelegate()
         
-        baseView.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "test")
+        baseView.tableView.register(SearchTableViewCell.self, forCellReuseIdentifier: SearchTableViewCell.identifier)
+        baseView.tableView.rowHeight = 50
     }
     
     override func configureBind() {
@@ -45,11 +47,17 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
             .disposed(by: disposeBag)
         
         viewModel.store.searchResult
-            .bind(to: baseView.tableView.rx.items(cellIdentifier: "test", cellType: UITableViewCell.self)) { row, item, cell in
-                cell.textLabel?.text = item.artistViewUrl
+            .bind(to: baseView.tableView.rx.items(cellIdentifier: SearchTableViewCell.identifier, cellType: SearchTableViewCell.self)) { row, item, cell in
+                cell.thumbnailImage.kf.setImage(with: URL(string:item.artworkUrl100))
+                cell.musicNameLabel.text = item.trackName
             }
             .disposed(by: disposeBag)
-            
+        
+        baseView.tableView.rx.itemSelected
+            .bind(with: self, onNext: { owner, indexPath in
+                owner.baseView.tableView.deselectRow(at: indexPath, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }
 

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
@@ -53,10 +53,27 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
             }
             .disposed(by: disposeBag)
         
+        
         baseView.tableView.rx.itemSelected
             .bind(with: self, onNext: { owner, indexPath in
                 owner.baseView.tableView.deselectRow(at: indexPath, animated: true)
             })
+            .disposed(by: disposeBag)
+        
+        baseView.tableView.rx.modelSelected(iTunesResult.self)
+            .bind(with: self) { owner, data in
+                owner.viewModel.store.selectedData.onNext(data)
+            }
+            .disposed(by: disposeBag)
+        
+        
+        viewModel.store.detailViewURL
+            .bind(with: self) { owner, data in
+                if let collectionViewUrl = data {
+                    print(collectionViewUrl)
+
+                }
+            }
             .disposed(by: disposeBag)
     }
 }

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewController.swift
@@ -28,7 +28,7 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
         super.configureDelegate()
         
         baseView.tableView.register(SearchTableViewCell.self, forCellReuseIdentifier: SearchTableViewCell.identifier)
-        baseView.tableView.rowHeight = 50
+        baseView.tableView.delegate = self
     }
     
     override func configureBind() {
@@ -82,3 +82,12 @@ final class SearchViewController: BaseViewController<SearchView, SearchViewModel
     }
 }
 
+extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 66
+    }
+}

--- a/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewModel.swift
+++ b/LZTunes/LZTunes/Sources/Presenters/Search/SearchViewModel.swift
@@ -13,10 +13,12 @@ final class SearchViewModel: ViewModel {
     
     struct Input: Inputable {
         var searchActionRequested: PublishSubject<String> = PublishSubject()
+        var selectedData: PublishSubject<iTunesResult> = PublishSubject()
     }
     
     struct Output: Outputable {
-        var searchResult: PublishSubject<[iTunesResult]> = PublishSubject()
+        var searchResult: PublishRelay<[iTunesResult]> = PublishRelay()
+        var detailViewURL: PublishRelay<String?> = PublishRelay()
     }
     
     init() {
@@ -35,6 +37,11 @@ final class SearchViewModel: ViewModel {
         repository.searchResult
             .debug()
             .bind(to: store.searchResult)
+            .disposed(by: disposeBag)
+        
+        store.selectedData
+            .map { $0.collectionViewUrl }
+            .bind(to: store.detailViewURL)
             .disposed(by: disposeBag)
     }
 }

--- a/LZTunes/LZTunes/Sources/Utils/Models/iTunesResponse.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Models/iTunesResponse.swift
@@ -11,6 +11,9 @@ struct iTunesResponse: Decodable {
 }
 
 struct iTunesResult: Decodable {
-    let kind: String?
-    let artistViewUrl: String?
+    let trackName: String
+    let artworkUrl30: String
+    let artworkUrl100: String
+    let artistViewUrl: String
+    let collectionViewUrl: String?
 }

--- a/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
@@ -34,7 +34,8 @@ enum iTunesRouter: Router {
         switch self {
         case .search(searchText: let searchText):
             let queryItems = [
-                URLQueryItem(name: "term", value: searchText)
+                URLQueryItem(name: "term", value: searchText),
+                URLQueryItem(name: "media", value: "music")
             ]
             
             return queryItems

--- a/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
+++ b/LZTunes/LZTunes/Sources/Utils/Routers/iTunesRouter.swift
@@ -35,7 +35,7 @@ enum iTunesRouter: Router {
         case .search(searchText: let searchText):
             let queryItems = [
                 URLQueryItem(name: "term", value: searchText),
-                URLQueryItem(name: "media", value: "music")
+                URLQueryItem(name: "media", value: "music"),
             ]
             
             return queryItems
@@ -53,6 +53,7 @@ enum iTunesRouter: Router {
         
         if let composedURL = components?.url {
             let request = URLRequest(url: composedURL)
+            print(request.url)
             return request
         }
         


### PR DESCRIPTION
# 📱 *Pull requests* 🎶

🌿 **작업한 브랜치**
https://github.com/alpaka99/LZTunes/tree/%2310/Feat/Implement-Detail-UI

<br></br>

## 🔍 **작업한 결과**
### DetailSearchViewController 구현
> tableView.rx.modelSelected
- DetailSearchViewController를 구현했습니다. SearchViewController에서 tableView.modelSelected를 이용하여 선택된 데이터 값을 확인한 후, DetailViewModel 인스턴스에 데이터를 전달해주는 방법으로 구현했습니다.

### DetailSearchViewController
> WKWebView
- DetailSearchViewController는 간단하게 선택된 노래에 대한 webView를 보여주는 방식으로 구현했습니다.
- `외부에서 ViewModel을 생성한 후, DetailViewController에 주입해주는 방식`을 사용과, ViewModel 내부에서는 BehaviotSubject로 webView에 필요한 url의 String 값을 갖고 있기 때문에, BaseViewController에서 지정한 configureBind의 바인딩 순서가 문제가 되지 않았습니다.

<br></br>
## 🔫 **Trouble Shooting**

<br></br>
## 🔊 기타 공유사항
### Binding 시점
- 현재는 ViewModel 생성 -> ViewController 생성 -> ViewController의 ViewDidLoad에서 viewModel의 detailViewURL과 바인딩 진행의 순서로 로직이 이루어지고 있습니다. 문제는 ViewModel 생성이 ViewController보다 빨라야하기 때문에, ViewController의 바인딩은 필연적으로 ViewModel의 생성보다 느려질 수 밖에 없고, 따라서 ViewModel 내부의 값이 바로 ViewController에 띄워지기 위해서는 초기값을 갖는 BehaviorSubject 혹은 BehaviorRelay를 사용하는 방법 밖에 없습니다.
- 이 부분에 대해서는 추가적으로 DI에 대한 학습이 필요할것 같습니다

### 추가 기능 구현 생각
- 현재는 WebView를 이용하여 Detail화면을 띄우고 있지만, 추후에는 iTunesAPI 중 media를 직접 받아올 수 있는 기능을 통해 현재 선택한 노래에 대한 짧은 preview music을 받아오는 기능을 제작하고 싶습니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|DetailView와 연결 및 DetailView의 WebView 구현|![Simulator Screen Recording - iPhone 15 Pro - 2024-08-12 at 01 29 55](https://github.com/user-attachments/assets/9cea1020-8c2a-4657-a8e4-8dac52af9646)|
<br></br>

## 📟 관련 이슈
- Resolved: #10 
